### PR TITLE
Fix IndexOutOfRangeException in phone number formatting

### DIFF
--- a/TestPlugin/Plugin1.cs
+++ b/TestPlugin/Plugin1.cs
@@ -170,8 +170,14 @@ namespace PluginTest
             localPluginContext.Trace($"FormatPhoneNumber: Cleaned number: '{cleanNumber}' (length: {cleanNumber.Length})");
 
             var digitOnlyLength = cleanNumber.Replace("+", "").Length;
-            var firstDigit = cleanNumber.Replace("+", "")[0]; 
             localPluginContext.Trace($"FormatPhoneNumber: Digit-only length: {digitOnlyLength}");
+
+            // Check if we have any digits at all after cleaning
+            if (digitOnlyLength == 0)
+            {
+                localPluginContext.Trace("FormatPhoneNumber: No digits found after cleaning, returning empty string");
+                return string.Empty;
+            }
 
             try
             {

--- a/TestPlugin/Plugin1.cs
+++ b/TestPlugin/Plugin1.cs
@@ -191,7 +191,13 @@ namespace PluginTest
                         localPluginContext.Trace("FormatPhoneNumber: Clean number length >= 10, proceeding with international formatting");
                         // Example: +1 234 567 8900 or +44 20 1234 5678
                         localPluginContext.Trace($"FormatPhoneNumber: About to extract country code from: '{cleanNumber}'");
-                        var countryCode = cleanNumber.Substring(0, cleanNumber.StartsWith("+1") ? 2 : 3);
+                        var countryCodeLength = cleanNumber.StartsWith("+1") ? 2 : 3;
+                        if (cleanNumber.Length < countryCodeLength)
+                        {
+                            localPluginContext.Trace($"FormatPhoneNumber: Clean number too short ({cleanNumber.Length}) for expected country code length ({countryCodeLength}), returning as-is");
+                            return cleanNumber;
+                        }
+                        var countryCode = cleanNumber.Substring(0, countryCodeLength);
                         localPluginContext.Trace($"FormatPhoneNumber: Extracted country code: '{countryCode}'");
 
                         var remaining = cleanNumber.Substring(countryCode.Length);

--- a/TestProject1/UnitTest1.cs
+++ b/TestProject1/UnitTest1.cs
@@ -346,5 +346,53 @@ namespace TestProject1
 
             _fakedContext.ExecutePluginWith<PluginTest.Plugin1>(pluginContext);
         }
+
+        [Fact]
+        public void Test_plugin_handles_phone_with_only_special_characters()
+        {
+            var pluginContext = _fakedContext.GetDefaultPluginContext();
+            pluginContext.MessageName = "Update";
+
+            var guid1 = Guid.NewGuid();
+            var target = new Entity("contact") { Id = guid1 };
+            target.Attributes.Add("mobilephone", "+-()_");
+
+            ParameterCollection inputParameters = new ParameterCollection();
+            inputParameters.Add("Target", target);
+
+            ParameterCollection outputParameters = new ParameterCollection();
+            outputParameters.Add("id", guid1);
+
+            pluginContext.InputParameters = inputParameters;
+            pluginContext.OutputParameters = outputParameters;
+
+            _fakedContext.ExecutePluginWith<PluginTest.Plugin1>(pluginContext);
+
+            Assert.Equal("", target["mobilephone"]);
+        }
+
+        [Fact]
+        public void Test_plugin_handles_phone_with_plus_only()
+        {
+            var pluginContext = _fakedContext.GetDefaultPluginContext();
+            pluginContext.MessageName = "Update";
+
+            var guid1 = Guid.NewGuid();
+            var target = new Entity("contact") { Id = guid1 };
+            target.Attributes.Add("mobilephone", "+");
+
+            ParameterCollection inputParameters = new ParameterCollection();
+            inputParameters.Add("Target", target);
+
+            ParameterCollection outputParameters = new ParameterCollection();
+            outputParameters.Add("id", guid1);
+
+            pluginContext.InputParameters = inputParameters;
+            pluginContext.OutputParameters = outputParameters;
+
+            _fakedContext.ExecutePluginWith<PluginTest.Plugin1>(pluginContext);
+
+            Assert.Equal("", target["mobilephone"]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed IndexOutOfRangeException that occurred when processing malformed phone numbers containing only special characters (e.g., '+-()_')
- Added safety check to validate string length before attempting substring extraction in country code detection
- All existing tests continue to pass, including edge cases for malformed phone inputs

## Test plan
- [x] All 17 unit tests pass
- [x] Specific tests for edge cases (phone numbers with only special characters) validate the fix
- [x] Plugin handles malformed input gracefully by returning empty string instead of throwing exception

🤖 Generated with [Claude Code](https://claude.ai/code)