### PR TITLE
Fix IndexOutOfRangeException for phone numbers with no digits

### DIFF
--- a/TestPlugin/Plugin1.cs
+++ b/TestPlugin/Plugin1.cs
@@ -170,7 +170,12 @@ namespace PluginTest
             localPluginContext.Trace($"FormatPhoneNumber: Cleaned number: '{cleanNumber}' (length: {cleanNumber.Length})");
 
             var digitOnlyLength = cleanNumber.Replace("+", "").Length;
-            var firstDigit = cleanNumber.Replace("+", "")[0]; 
+            if (digitOnlyLength == 0)
+            {
+                localPluginContext.Trace("FormatPhoneNumber: No digits found in input, returning original value");
+                return phoneNumber;
+            }
+            var firstDigit = cleanNumber.Replace("+", "")[0];
             localPluginContext.Trace($"FormatPhoneNumber: Digit-only length: {digitOnlyLength}");
 
             try

--- a/TestProject1/UnitTest1.cs
+++ b/TestProject1/UnitTest1.cs
@@ -308,6 +308,30 @@ namespace TestProject1
         }
 
         [Fact]
+        public void Test_plugin_handles_phone_with_no_digits()
+        {
+            var pluginContext = _fakedContext.GetDefaultPluginContext();
+            pluginContext.MessageName = "Update";
+
+            var guid1 = Guid.NewGuid();
+            var target = new Entity("contact") { Id = guid1 };
+            target.Attributes.Add("mobilephone", "+-()_");
+
+            ParameterCollection inputParameters = new ParameterCollection();
+            inputParameters.Add("Target", target);
+
+            ParameterCollection outputParameters = new ParameterCollection();
+            outputParameters.Add("id", guid1);
+
+            pluginContext.InputParameters = inputParameters;
+            pluginContext.OutputParameters = outputParameters;
+
+            _fakedContext.ExecutePluginWith<PluginTest.Plugin1>(pluginContext);
+
+            Assert.Equal("+-()_", target["mobilephone"]);
+        }
+
+        [Fact]
         public void Test_plugin_throws_exception_with_null_service_provider()
         {
             var plugin = new PluginTest.Plugin1();


### PR DESCRIPTION
## Summary
- Fixed `IndexOutOfRangeException` in `FormatPhoneNumber` when a contact's mobile phone contains only special characters (e.g. `+-()_`) and no actual digits
- After stripping non-digit characters, the code attempted to access index `[0]` on an empty string — added an early return when no digits remain
- Added unit test reproducing the exact production scenario

## Test plan
- [x] New test `Test_plugin_handles_phone_with_no_digits` passes with input `+-()_`
- [x] All 16 existing tests continue to pass
- [ ] Manual verification in sandbox environment after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)